### PR TITLE
[master]  Add Quote Char support (2)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 mdouchement
+Copyright (c) 2015-2016 mdouchement
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # iosupport
 [![Build Status](https://travis-ci.org/mdouchement/iosupport.svg?branch=master)](https://travis-ci.org/mdouchement/iosupport)
 
-It provides some io supports for GoLang.
+It provides some io supports for GoLang:
+- Read large files (line length and large amount of lines)
+- Parse CSV files according the RFC4180, but:
+  - It does not support `\r\n` in quoted field
+  - It does not support comment
+- Sort CSV on one or several columns
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # iosupport
 [![Build Status](https://travis-ci.org/mdouchement/iosupport.svg?branch=master)](https://travis-ci.org/mdouchement/iosupport)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](https://godoc.org/github.com/mdouchement/iosupport)
 
 It provides some io supports for GoLang:
 - Read large files (line length and large amount of lines)

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,41 @@
+// Copyright 2015-2016 mdouchement. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+// Package iosupport reads and writes large text files.
+// It can count lines, bytes, characters and words contained in the give file
+// and it can parse and sort CSV files.
+//
+// There are many kinds of CSV files; this package supports the format
+// described in RFC 4180 except newlines in quoted fields.
+//
+// A CSV file contains zero or more records of one or more fields per record.
+// Each record is separated by the newline character. The final record may
+// optionally be followed by a newline character.
+//	field1,field2,field3
+//
+// White space is considered part of a field.
+//
+// Carriage returns before newline characters are silently removed.
+//
+// Fields which start and stop with the quote character " are called
+// quoted-fields. The beginning and ending quote are not part of the
+// field.
+//
+// The source:
+//
+//	normal string,"quoted-field"
+//
+// results in the fields
+//
+//	{`normal string`, `quoted-field`}
+//
+// Within a quoted-field a quote character followed by a second quote
+// character is considered a single quote.
+//
+//	"the ""word"" is true","a ""quoted-field"""
+//
+// results in
+//
+//	{`the "word" is true`, `a "quoted-field"`}
+package iosupport

--- a/file.go
+++ b/file.go
@@ -2,7 +2,7 @@ package iosupport
 
 import "io"
 
-// FileReader is an interface for supported File by Scanner
+// FileReader is an interface for supported File by Scanner.
 type FileReader interface {
 	ReadAt(b []byte, off int64) (n int, err error)
 	Seek(offset int64, whence int) (ret int64, err error)
@@ -12,7 +12,7 @@ type FileReader interface {
 	io.Reader
 }
 
-// FileWriter is an interface for supported File by Scanner
+// FileWriter is an interface for supported File by Scanner.
 type FileWriter interface {
 	Close() error
 

--- a/scanner.go
+++ b/scanner.go
@@ -24,7 +24,7 @@ import (
 //   println(line)
 // })
 //
-// See other methods for custom usage
+// See other methods for custom usage.
 
 var (
 	// LF -> linefeed
@@ -34,17 +34,17 @@ var (
 	newLines      = []byte{CR, LF}
 )
 
-// Scanner conatins all stuff for reading a buffered file
+// Scanner conatins all stuff for reading a buffered file.
 type Scanner struct {
-	f               FileReader    // The file provided by the client.
-	r               *bufio.Reader // Buffered reader on given file.
-	keepnls         bool          // Keep the newline sequence in returned strings
+	f       FileReader    // The file provided by the client.
+	r       *bufio.Reader // Buffered reader on given file.
+	keepnls bool          // Keep the newline sequence in returned strings
 	newlineSequence []byte        // Backup line terminators sequence (e.g. \r\n)
-	token           []byte        // Last token returned by split (scan).
-	err             error         // Sticky error.
-	line            int           // index of current read line
-	offset          uint64        // Offset of the start of the read line
-	limit           uint32        // Length of the read line including newline sequence
+	token   []byte        // Last token returned by split (scan).
+	err     error         // Sticky error.
+	line    int           // index of current read line.
+	offset  uint64        // Offset of the start of the read line.
+	limit   uint32        // Length of the read line including newline sequence.
 }
 
 // NewScanner instanciates a Scanner
@@ -57,7 +57,7 @@ func NewScanner(f FileReader) *Scanner {
 	}
 }
 
-// KeepNewlineSequence keeps the newline sequence in read lines
+// KeepNewlineSequence keeps the newline sequence in read lines.
 func (s *Scanner) KeepNewlineSequence(b bool) {
 	s.keepnls = b
 }
@@ -88,17 +88,17 @@ func (s *Scanner) Err() error {
 	return s.err
 }
 
-// Line return the index of the current line
+// Line return the index of the current line.
 func (s *Scanner) Line() int {
 	return s.line
 }
 
-// Offset return the byte offset of the current line
+// Offset return the byte offset of the current line.
 func (s *Scanner) Offset() uint64 {
 	return s.offset
 }
 
-// Limit return the byte length of the current line including newline sequence
+// Limit return the byte length of the current line including newline sequence.
 func (s *Scanner) Limit() uint32 {
 	return s.limit
 }
@@ -141,7 +141,7 @@ func (s *Scanner) ScanLine() bool {
 	}
 }
 
-// EachLine iterate on each line and execute the given function
+// EachLine iterate on each line and execute the given function.
 func (s *Scanner) EachLine(fn func([]byte, error)) {
 	s.Reset()
 	for s.ScanLine() {
@@ -149,7 +149,7 @@ func (s *Scanner) EachLine(fn func([]byte, error)) {
 	}
 }
 
-// EachString iterates on each line as string format and execute the given function
+// EachString iterates on each line as string format and execute the given function.
 func (s *Scanner) EachString(fn func(string, error)) {
 	s.Reset()
 	for s.ScanLine() {
@@ -176,12 +176,12 @@ func (s *Scanner) setErr(err error) {
 	}
 }
 
-// IsLineEmpty says if the current line is empty (only when newline character is not keeped)
+// IsLineEmpty says if the current line is empty (only when newline character is not keeped).
 func (s *Scanner) IsLineEmpty() bool {
 	return len(s.token) == 0
 }
 
-// Reset seek to top of file and clean buffer
+// Reset seek to top of file and clean buffer.
 func (s *Scanner) Reset() {
 	s.f.Seek(0, 0)
 	s.line = -1

--- a/scanner.go
+++ b/scanner.go
@@ -36,15 +36,15 @@ var (
 
 // Scanner conatins all stuff for reading a buffered file.
 type Scanner struct {
-	f       FileReader    // The file provided by the client.
-	r       *bufio.Reader // Buffered reader on given file.
-	keepnls bool          // Keep the newline sequence in returned strings
+	f               FileReader    // The file provided by the client.
+	r               *bufio.Reader // Buffered reader on given file.
+	keepnls         bool          // Keep the newline sequence in returned strings
 	newlineSequence []byte        // Backup line terminators sequence (e.g. \r\n)
-	token   []byte        // Last token returned by split (scan).
-	err     error         // Sticky error.
-	line    int           // index of current read line.
-	offset  uint64        // Offset of the start of the read line.
-	limit   uint32        // Length of the read line including newline sequence.
+	token           []byte        // Last token returned by split (scan).
+	err             error         // Sticky error.
+	line            int           // index of current read line.
+	offset          uint64        // Offset of the start of the read line.
+	limit           uint32        // Length of the read line including newline sequence.
 }
 
 // NewScanner instanciates a Scanner

--- a/tsv_indexer.go
+++ b/tsv_indexer.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 )
 
-// TsvLine describes the line's details from a TSV
+// TsvLine describes the line's details from a TSV.
 type TsvLine struct {
 	Comparable string
 	Offset     uint64
@@ -22,7 +22,7 @@ type seeker struct {
 	offset uint64
 }
 
-// TsvIndexer contains all stuff for indexing columns from a TSV
+// TsvIndexer contains all stuff for indexing and sorting columns from a TSV.
 type TsvIndexer struct {
 	parser        *TsvParser
 	Header        bool
@@ -35,7 +35,7 @@ type TsvIndexer struct {
 	LineThreshold int
 }
 
-// NewTsvIndexer instanciates a new TsvIndexer
+// NewTsvIndexer instanciates a new TsvIndexer.
 func NewTsvIndexer(scannerFunc func() *Scanner, header bool, separator string, fields []string) *TsvIndexer {
 	sc := scannerFunc()
 	sc.Reset()
@@ -52,13 +52,13 @@ func NewTsvIndexer(scannerFunc func() *Scanner, header bool, separator string, f
 	}
 }
 
-// CloseIO closes all opened IO
+// CloseIO closes all opened IO.
 func (ti *TsvIndexer) CloseIO() {
 	ti.parser.Scanner.f.Close()
 	ti.releaseSeekers()
 }
 
-// Analyze parses the TSV and generates the indexes
+// Analyze parses the TSV and generates the indexes.
 func (ti *TsvIndexer) Analyze() error {
 	if !ti.Header {
 		re := regexp.MustCompile(`var(\d+)`)
@@ -82,12 +82,12 @@ func (ti *TsvIndexer) Analyze() error {
 	return nil
 }
 
-// Sort sorts TsvLine on its comparables
+// Sort sorts TsvLine on its comparables.
 func (ti *TsvIndexer) Sort() {
 	sort.Sort(ti.Lines)
 }
 
-// Transfer writes sorted TSV into a new file
+// Transfer writes sorted TSV into a new file.
 func (ti *TsvIndexer) Transfer(output FileWriter) error {
 	w := bufio.NewWriter(output)
 	ns := ti.parser.NewlineSequence()

--- a/tsv_parser.go
+++ b/tsv_parser.go
@@ -2,6 +2,27 @@ package iosupport
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
+)
+
+// A ParseError is returned for parsing errors.
+// The first line is 1.  The first column is 0.
+type ParseError struct {
+	Line   int   // Line where the error occurred
+	Column int   // Column (rune index) where the error occurred
+	Err    error // The actual error
+}
+
+func (e *ParseError) Error() string {
+	return fmt.Sprintf("line %d, column %d: %s", e.Line, e.Column, e.Err)
+}
+
+var (
+	// ErrBareQuote -> bare \" in non-quoted-field
+	ErrBareQuote = errors.New("bare \" in non-quoted-field")
+	// ErrQuote -> extraneous \" in field
+	ErrQuote = errors.New("extraneous \" in field")
 )
 
 // UnescapeSeparator cleans composed separator like \t
@@ -20,12 +41,21 @@ func TrimNewline(line []byte) []byte {
 }
 
 // A TsvParser reads records from a TSV-encoded file.
+// As returned by NewTsvParser, a TsvParser expects input conforming to RFC 4180 (except the warning section).
+//
+// If LazyQuotes is true, a quote may appear in an unquoted field and a
+// non-doubled quote may appear in a quoted field.
+//
+// /!\ Warning:
+// - It does not support \r\n in quoted field.
+// - It does not support comment.
 type TsvParser struct {
 	*Scanner
-	err       error // Sticky error.
-	Separator []byte
-	QuoteChar byte
-	row       [][]byte
+	err        error // Sticky error.
+	Separator  byte
+	QuoteChar  byte
+	LazyQuotes bool // allow lazy quotes
+	row        [][]byte
 }
 
 // NewTsvParser inatanciates a new TsvParser
@@ -33,8 +63,17 @@ func NewTsvParser(sc *Scanner, separator byte) *TsvParser {
 	sc.Reset()
 	return &TsvParser{
 		Scanner:   sc,
-		Separator: []byte{separator},
+		Separator: separator,
 		QuoteChar: '"',
+	}
+}
+
+// error creates a new ParseError based on err.
+func (tp *TsvParser) error(col int, err error) error {
+	return &ParseError{
+		Line:   tp.Line(),
+		Column: col,
+		Err:    err,
 	}
 }
 
@@ -71,5 +110,96 @@ func (tp *TsvParser) ScanRow() bool {
 
 // Simple fields parser
 func (tp *TsvParser) parseFields() [][]byte {
-	return bytes.Split(TrimNewline(tp.Bytes()), tp.Separator)
+	fields := [][]byte{}
+	r := newReader(tp.Bytes())
+	field := tp.parseField(r)
+	for field != nil {
+		fields = append(fields, field)
+		field = tp.parseField(r)
+	}
+	return fields
+}
+
+func (tp *TsvParser) parseField(r *reader) []byte {
+	var field bytes.Buffer
+
+	b, ok := r.readByte()
+	if !ok {
+		return nil
+	}
+
+	switch b {
+	case tp.QuoteChar:
+		// quoted field
+		for {
+			b, ok = r.readByte()
+			if !ok {
+				// End of row reached
+				if !tp.LazyQuotes {
+					tp.err = tp.error(r.index, ErrQuote)
+					return nil
+				}
+				return field.Bytes()
+			}
+
+			// CSV quote escaping case
+			if b == tp.QuoteChar {
+				b, ok = r.readByte() // read next byte after the double-quote
+				if b == tp.Separator || !ok {
+					// End of field or end of row reached
+					return field.Bytes()
+				}
+				if b != tp.QuoteChar {
+					if !tp.LazyQuotes {
+						r.index--
+						tp.err = tp.error(r.index, ErrQuote)
+						return nil
+					}
+					// accept the bare quote
+					field.WriteRune('"')
+				}
+			}
+
+			field.WriteByte(b)
+		}
+	default:
+		// unquoted field
+		for {
+			field.WriteByte(b)
+			b, ok = r.readByte()
+			if b == tp.Separator || !ok {
+				// End of field or end of row reached
+				return field.Bytes()
+			}
+
+			if !tp.LazyQuotes && b == tp.QuoteChar {
+				tp.err = tp.error(r.index, ErrBareQuote)
+				return nil
+			}
+		}
+	}
+}
+
+// ------------------ //
+// Parsing stuff      //
+// ------------------ //
+
+type reader struct {
+	index int
+	row   []byte
+}
+
+func newReader(row []byte) *reader {
+	return &reader{
+		index: 0,
+		row:   row,
+	}
+}
+
+func (r *reader) readByte() (byte, bool) {
+	if r.index >= len(r.row) {
+		return '\x00', false
+	}
+	defer func() { r.index++ }()
+	return r.row[r.index], true
 }

--- a/tsv_parser.go
+++ b/tsv_parser.go
@@ -255,7 +255,7 @@ func newReader(row []byte) *reader {
 
 func (r *reader) readByte() (byte, bool) {
 	if r.index >= len(r.row) {
-		return '\x00', false
+		return '\u0000', false
 	}
 	defer func() { r.index++ }()
 	return r.row[r.index], true

--- a/tsv_parser_test.go
+++ b/tsv_parser_test.go
@@ -97,3 +97,29 @@ func BenchmarkParseFields(b *testing.B) {
 		iosupport.ParseFields(tp)
 	}
 }
+
+func BenchmarkParseFieldsWithQuotes(b *testing.B) {
+	path := generateTmpFile(tsvIndexerInput)
+	file, err := os.Open(path)
+	check(err)
+	sc := iosupport.NewScanner(file)
+
+	tp := iosupport.NewTsvParser(sc, ',')
+	iosupport.SetToken(tp, []byte(`c1,c2,c3,c4,c5,c6,"c,7",c8,c9,10`))
+	for i := 0; i < b.N; i++ {
+		iosupport.ParseFields(tp)
+	}
+}
+
+func BenchmarkParseFieldsWithDoubleQuotes(b *testing.B) {
+	path := generateTmpFile(tsvIndexerInput)
+	file, err := os.Open(path)
+	check(err)
+	sc := iosupport.NewScanner(file)
+
+	tp := iosupport.NewTsvParser(sc, ',')
+	iosupport.SetToken(tp, []byte(`c1,c2,c3,c4,c5,c6,"c ""is"" 7",c8,c9,10`))
+	for i := 0; i < b.N; i++ {
+		iosupport.ParseFields(tp)
+	}
+}

--- a/tsv_parser_test.go
+++ b/tsv_parser_test.go
@@ -11,7 +11,9 @@ import (
 var tsvParserInput = `c1,"c,2",c3
 val45,val2,val3
 val40,"val42 ""the"" best",val6
-`
+v1,,v3
+v4,v5,
+a,b,c`
 
 var tsvParserErrQuote = []struct {
 	col int
@@ -34,6 +36,9 @@ func TestTsvParser(t *testing.T) {
 		[]string{"c1", "c,2", "c3"},
 		[]string{"val45", "val2", "val3"},
 		[]string{"val40", "val42 \"the\" best", "val6"},
+		[]string{"v1", "", "v3"},
+		[]string{"v4", "v5", ""},
+		[]string{"a", "b", "c"},
 	}
 	for parser.ScanRow() {
 		check(parser.Err())
@@ -53,8 +58,8 @@ func TestTsvParser(t *testing.T) {
 		}
 		for j, expected := range expectedRows[i] {
 			if expected != actual[j] {
-				t.Logf("expected '%v' - actual '%v' at index %d", expectedRows[i], actual, i)
-				t.Errorf("Expected '%v' but got '%v' at index %d", expected, actual[j], i)
+				t.Logf("Expected '%v' - actual '%v' at index %d", expectedRows[i], actual, i)
+				t.Errorf("  -> Expected '%v' but got '%v' at index %d", expected, actual[j], i)
 			}
 		}
 		i++

--- a/wc_test.go
+++ b/wc_test.go
@@ -7,8 +7,10 @@ import (
 	"github.com/mdouchement/iosupport"
 )
 
+var wordCountInput = "The first line.\nThe secönd line :)\n\n"
+
 func TestWordCountPerform(t *testing.T) {
-	path := generateTmpFile()
+	path := generateTmpFile(wordCountInput)
 	file, err := os.Open(path)
 	check(err)
 	defer file.Close()
@@ -36,7 +38,7 @@ func TestWordCountPerform(t *testing.T) {
 }
 
 func TestWordCountWithCustomOptions(t *testing.T) {
-	path := generateTmpFile()
+	path := generateTmpFile(wordCountInput)
 	file, err := os.Open(path)
 	check(err)
 	defer file.Close()
@@ -48,8 +50,8 @@ func TestWordCountWithCustomOptions(t *testing.T) {
 	err = wc.Perform()
 	check(err)
 
-	if wc.Bytes != 36 {
-		t.Errorf("Invalid number of bytes. Expected 36 but got %v", wc.Bytes)
+	if wc.Bytes != 37 {
+		t.Errorf("Invalid number of bytes. Expected 37 but got %v", wc.Bytes)
 	}
 
 	if wc.Chars != 0 {


### PR DESCRIPTION
Add quote char support ported from https://golang.org/pkg/encoding/csv. It almost supports the RFC 4180 but it does not support the following:
- `\r\n` in quoted field
- commented line

> Lots of documentation is updated

------------
**Performances**
This implementation is 85% slower than the previous:

- String's split
```
BenchmarkParseFields-8 	 3000000       	       581 ns/op
ok     	github.com/mdouchement/iosupport       	2.346s
```

- ~RFC4180
```
BenchmarkParseFields-8 	  300000       	      4034 ns/op
ok     	github.com/mdouchement/iosupport       	1.268s
```

------------

- [x] it needs to be successfully tested with several files
- [x] run performance benchmark
  - For the same dataset (without quote char) there is no performance gap with the old implementation.
- [x] profiling and optimizations