### PR TITLE
[master] Malformed CSV lines could be silently discarded during sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ func main() {
   }
 
   // See tsv_indexer.go for more examples
-  indexer = iosupport.NewTsvIndexer(sc, iosupport.Header(), iosupport.Separator(","), iosupport.Fields("col2", "col1")) // scanner, headerIsPresent, separator, fieldsForSorting
+  indexer = iosupport.NewTsvIndexer(sc, iosupport.HasHeader(), iosupport.Separator(","), iosupport.Fields("col2", "col1")) // scanner, headerIsPresent, separator, fieldsForSorting
   defer indexer.CloseIO()
   err := indexer.Analyze() // creates lines index
   check(err)

--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ func main() {
 
   // See tsv_indexer.go for more examples
   indexer = iosupport.NewTsvIndexer(sc, iosupport.Header(), iosupport.Separator(","), iosupport.Fields("col2", "col1")) // scanner, headerIsPresent, separator, fieldsForSorting
-  indexer.LineThreshold = 25000 // Number of lines between each scanner's seek (see TsvIndexer#selectSeeker)
   defer indexer.CloseIO()
   err := indexer.Analyze() // creates lines index
   check(err)

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ func main() {
   }
 
   // See tsv_indexer.go for more examples
-  indexer = iosupport.NewTsvIndexer(sc, true, ",", []string{"col2", "col1"}) // scanner, headerIsPresent, separator, fieldsForSorting
+  indexer = iosupport.NewTsvIndexer(sc, iosupport.Header(), iosupport.Separator(","), iosupport.Fields("col2", "col1")) // scanner, headerIsPresent, separator, fieldsForSorting
   indexer.LineThreshold = 25000 // Number of lines between each scanner's seek (see TsvIndexer#selectSeeker)
   defer indexer.CloseIO()
   err := indexer.Analyze() // creates lines index

--- a/examples/tsvsorter/main.go
+++ b/examples/tsvsorter/main.go
@@ -88,8 +88,12 @@ func action(context *cli.Context) error {
 		}
 		return iosupport.NewScanner(file)
 	}
-	indexer := iosupport.NewTsvIndexer(sc, iosupport.Separator(separator), iosupport.Fields(fields...), iosupport.SkipMalformattedLines())
-	indexer.Header = header
+	indexer := iosupport.NewTsvIndexer(sc,
+		iosupport.Header(header),
+		iosupport.Separator(separator),
+		iosupport.Fields(fields...),
+		iosupport.SkipMalformattedLines(),
+		iosupport.DropEmptyIndexedFields())
 	defer indexer.CloseIO()
 
 	elapsed := time.Since(start)

--- a/examples/tsvsorter/main.go
+++ b/examples/tsvsorter/main.go
@@ -88,7 +88,8 @@ func action(context *cli.Context) error {
 		}
 		return iosupport.NewScanner(file)
 	}
-	indexer := iosupport.NewTsvIndexer(sc, header, separator, fields)
+	indexer := iosupport.NewTsvIndexer(sc, iosupport.Separator(separator), iosupport.Fields(fields...), iosupport.SkipMalformattedLines())
+	indexer.Header = header
 	defer indexer.CloseIO()
 
 	elapsed := time.Since(start)

--- a/tsv_indexer_options.go
+++ b/tsv_indexer_options.go
@@ -11,8 +11,15 @@ type Options struct {
 
 type Option func(*Options)
 
-// Header is present.
-func Header() Option {
+// Header is present or not.
+func Header(header bool) Option {
+	return func(opts *Options) {
+		opts.Header = header
+	}
+}
+
+// HasHeader is present.
+func HasHeader() Option {
 	return func(opts *Options) {
 		opts.Header = true
 	}

--- a/tsv_indexer_options.go
+++ b/tsv_indexer_options.go
@@ -1,0 +1,46 @@
+package iosupport
+
+type Options struct {
+	Header                 bool
+	Separator              byte
+	Fields                 []string
+	DropEmptyIndexedFields bool
+	SkipMalformattedLines  bool
+}
+
+type Option func(*Options)
+
+// Header is present.
+func Header() Option {
+	return func(opts *Options) {
+		opts.Header = true
+	}
+}
+
+// Separator of the TSV.
+func Separator(separator string) Option {
+	return func(opts *Options) {
+		opts.Separator = UnescapeSeparator(separator)
+	}
+}
+
+// Fields on which the TSV can be sorted.
+func Fields(fields ...string) Option {
+	return func(opts *Options) {
+		opts.Fields = fields
+	}
+}
+
+// DropEmptyIndexedFields removes the lines where the comparable is empty.
+func DropEmptyIndexedFields() Option {
+	return func(opts *Options) {
+		opts.DropEmptyIndexedFields = true
+	}
+}
+
+// SkipMalformattedLines ignores mal-formatted lines.
+func SkipMalformattedLines() Option {
+	return func(opts *Options) {
+		opts.SkipMalformattedLines = true
+	}
+}

--- a/tsv_indexer_options.go
+++ b/tsv_indexer_options.go
@@ -6,6 +6,7 @@ type Options struct {
 	Fields                 []string
 	DropEmptyIndexedFields bool
 	SkipMalformattedLines  bool
+	LineThreshold          int
 }
 
 type Option func(*Options)
@@ -42,5 +43,14 @@ func DropEmptyIndexedFields() Option {
 func SkipMalformattedLines() Option {
 	return func(opts *Options) {
 		opts.SkipMalformattedLines = true
+	}
+}
+
+// LineThreshold defines the number of file's seekers. One seeker per LineThreshold.
+// The number of seekers increase the Transfer speed during sort.
+// default: 2500000
+func LineThreshold(threshold int) Option {
+	return func(opts *Options) {
+		opts.LineThreshold = threshold
 	}
 }

--- a/tsv_indexer_test.go
+++ b/tsv_indexer_test.go
@@ -133,7 +133,7 @@ func TestTsvIndexerAnalyzeSortWithEmptyComparableDropping(t *testing.T) {
 	file, actual, expected := prepareTsvIndexer(tsvIndexerInputAnalyzeSort)
 	defer file.Close()
 
-	actual.DropEmptyLines(true)
+	actual.DropEmptyIndexedFields = true
 	actual.Fields = tsvIndexerInputFieldsAnalyzeSort
 	actual.Analyze()
 
@@ -142,6 +142,11 @@ func TestTsvIndexerAnalyzeSortWithEmptyComparableDropping(t *testing.T) {
 
 	t.Logf("expected.Lines: %v", expected.Lines)
 	t.Logf("actual.Lines:   %v", actual.Lines)
+
+	if len(actual.Lines) != len(expected.Lines) {
+		t.Errorf("Expected '%v' lines but got '%v'", len(expected.Lines), len(actual.Lines))
+	}
+
 	for i, expectedLine := range expected.Lines {
 		if actual.Lines[i].Offset != expectedLine.Offset {
 			t.Errorf("Expected offset '%v' but got '%v' at index %v", expectedLine.Offset, actual.Lines[i].Offset, i)
@@ -246,9 +251,9 @@ func prepareTsvIndexer(input string) (file *os.File, actual *iosupport.TsvIndexe
 		return iosupport.NewScanner(file)
 	}
 
-	actual = iosupport.NewTsvIndexer(sc, true, ",", tsvIndexerInputFields)
+	actual = iosupport.NewTsvIndexer(sc, iosupport.Header(), iosupport.Separator(","), iosupport.Fields(tsvIndexerInputFields...))
 
-	expected = iosupport.NewTsvIndexer(sc, true, ",", tsvIndexerInputFields)
+	expected = iosupport.NewTsvIndexer(sc, iosupport.Header(), iosupport.Separator(","), iosupport.Fields(tsvIndexerInputFields...))
 	// expected.I = iosupport.NewIndexer(sc())
 	// expected.I.NbOfLines = 3
 

--- a/tsv_indexer_test.go
+++ b/tsv_indexer_test.go
@@ -289,9 +289,9 @@ func prepareTsvIndexer(input string) (file *os.File, actual *iosupport.TsvIndexe
 		return iosupport.NewScanner(file)
 	}
 
-	actual = iosupport.NewTsvIndexer(sc, iosupport.Header(), iosupport.Separator(","), iosupport.Fields(tsvIndexerInputFields...))
+	actual = iosupport.NewTsvIndexer(sc, iosupport.HasHeader(), iosupport.Separator(","), iosupport.Fields(tsvIndexerInputFields...))
 
-	expected = iosupport.NewTsvIndexer(sc, iosupport.Header(), iosupport.Separator(","), iosupport.Fields(tsvIndexerInputFields...))
+	expected = iosupport.NewTsvIndexer(sc, iosupport.HasHeader(), iosupport.Separator(","), iosupport.Fields(tsvIndexerInputFields...))
 	// expected.I = iosupport.NewIndexer(sc())
 	// expected.I.NbOfLines = 3
 


### PR DESCRIPTION
- `TsvIndexer` now uses [functional options](https://github.com/tmrts/go-patterns/blob/master/idiom/functional-options.md) pattern.